### PR TITLE
fix: improves the path matching for multi-line and fix minor bugs

### DIFF
--- a/fix-esm-import-path.js
+++ b/fix-esm-import-path.js
@@ -82,8 +82,8 @@ function scanModuleMainFile({ file }) {
 }
 
 function scanModule({ srcFile, importCode, name }) {
-  if (name.startsWith('node:')) {
-    // e.g. 'node:fs/promises'
+  if (name.startsWith('node:') || !name.startsWith('/')) {
+    // e.g. 'node:fs/promises' or 'fs/promises'
     return
   }
   let numOfDirInName = name.split('/').length - 1

--- a/fix-esm-import-path.js
+++ b/fix-esm-import-path.js
@@ -244,10 +244,10 @@ function scanFile({ srcFile }) {
     /.*export .* from '(.*?)'.*/g,
     /.*export .* from "(.*?)".*/g,
     // handle multi-line import/export with bracket, suggested by fox1t
-    /.*import\s*{[^}]*}\s*from\s*'(.*?)'.*/g,
-    /.*import\s*{[^}]*}\s*from\s*"(.*?)".*/g,
-    /.*export\s*{[^}]*}\s*from\s*'(.*?)'.*/g,
-    /.*export\s*{[^}]*}\s*from\s*"(.*?)".*/g,
+    /.*import\s*(?:type\s*)?{[^}]*}\s*from\s*'(.*?)'.*/g,
+    /.*import\s*(?:type\s*)?{[^}]*}\s*from\s*"(.*?)".*/g,
+    /.*export\s*(?:type\s*)?{[^}]*}\s*from\s*'(.*?)'.*/g,
+    /.*export\s*(?:type\s*)?{[^}]*}\s*from\s*"(.*?)".*/g,
   ]) {
     for (let match of code.matchAll(regex)) {
       let [importCode, name] = match

--- a/fix-esm-import-path.js
+++ b/fix-esm-import-path.js
@@ -117,12 +117,12 @@ function resolveImportName({ srcFile, name }) {
   if (name.startsWith('/')) {
     return { type: 'absolute', name }
   }
-  if (name.startsWith('./')) {
+  if (name.startsWith('./') || name === '.') {
     let dir = path.dirname(srcFile)
     name = path.join(dir, name)
     return { type: 'relative', name }
   }
-  if (name.startsWith('../')) {
+  if (name.startsWith('../') || name === '..') {
     let dir = path.dirname(srcFile)
     name = path.join(dir, name)
     return { type: 'relative', name }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,5 @@
   "bugs": {
     "url": "https://github.com/beenotung/fix-esm-import-path/issues"
   },
-  "homepage": "https://github.com/beenotung/fix-esm-import-path#readme",
-  "packageManager": "pnpm@7.14.2+sha512.352c6b21a456d3b8c5410d5f3c514e03c78c7eea20b0c7b280e29ddf3685832241768d6887ad6397626359cfb0d17373588306effbfd1caee73fc4532f934ede"
+  "homepage": "https://github.com/beenotung/fix-esm-import-path#readme"
 }

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
   "bugs": {
     "url": "https://github.com/beenotung/fix-esm-import-path/issues"
   },
-  "homepage": "https://github.com/beenotung/fix-esm-import-path#readme"
+  "homepage": "https://github.com/beenotung/fix-esm-import-path#readme",
+  "packageManager": "pnpm@7.14.2+sha512.352c6b21a456d3b8c5410d5f3c514e03c78c7eea20b0c7b280e29ddf3685832241768d6887ad6397626359cfb0d17373588306effbfd1caee73fc4532f934ede"
 }


### PR DESCRIPTION
While working on the usual monorepo, I discovered that the two regexp we added yesterday don't support the `import type` and `export type` multiline variants.

For example:
```ts
export type {
  AutomationReferencesArgs,
  AutomationFlowIdFilter,
  AutomationFlowFilter,
  AutomationFlowStatusFilter,
  AutomationFlowsFilter,
  AutomationFlowAutomationIdFilter,
} from './interfaces';
```

This PR fixes it, adding an optional non-capturing group to handle the `type` keyword.

Another fix I added is for barrel files imported by `'.'` and '`..` that were erroneously flagged as "modules" and therefore ignored by the fix.
```ts
import { populate } from '.';
```

Finally, the PR also fixes module imports from subpaths
```ts
import fs from 'fs/promises'
```