### PR TITLE
fix: ensure barrel files are properly detected when the scripts run on windows

### DIFF
--- a/fix-esm-import-path.js
+++ b/fix-esm-import-path.js
@@ -162,7 +162,7 @@ function scanImport({ srcFile, importCode, name }) {
           srcFile,
           importCode,
           from: name,
-          to: importFile.startsWith(importName + '/index')
+          to: importFile.startsWith(importName + path.sep + 'index')
             ? name + '/index.js'
             : name + '.js',
         })


### PR DESCRIPTION
On Windows, the path separator is `\`, which will cause the modified if clause to not be true on Windows.

[`path.sep`](https://nodejs.org/api/path.html#pathsep) is platform-adaptive: it return `\` on windows, `/` on POSIX.

Alternatively, I could've used `path.join`, but I elected to stay truthful and as close as possible to the current logic and rely on string concatenations.